### PR TITLE
Mapping API Endpoints With Resources

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,11 @@
 import * as React from "react";
-import { Admin } from 'react-admin';
+import { Admin, ListGuesser, Resource } from 'react-admin';
 import jsonServerProvider from 'ra-data-json-server';
 
 const dataProvider = jsonServerProvider('https://jsonplaceholder.typicode.com');
-const App = () => <Admin dataProvider={dataProvider} />;
+const App = () => <Admin dataProvider={dataProvider} >
+    <Resource name="users" list={ListGuesser} />
+</Admin>;
 
 export default App;
+ 


### PR DESCRIPTION
We’ll start by adding a list of users.

The <Admin> component expects one or more <Resource> child components. Each resource maps a name to an endpoint in the API. Edit the App.js file to add a resource named users:
import * as React from "react";
import { Admin, ListGuesser, Resource } from 'react-admin';
import jsonServerProvider from 'ra-data-json-server';

const dataProvider = jsonServerProvider('https://jsonplaceholder.typicode.com');
const App = () => <Admin dataProvider={dataProvider} >
    <Resource name="users" list={ListGuesser} />
</Admin>;

export default App;
 
 The line <Resource name="users" /> informs react-admin to fetch the “users” records from the https://jsonplaceholder.typicode.com/users URL. <Resource> also defines the React components to use for each CRUD operation (list, create, edit, and show).

The list={ListGuesser} prop means that react-admin should use the <ListGuesser> component to display the list of posts. This component guesses the format to use for the columns of the list based on the data fetched from the API.

If you look at the network tab in the browser developer tools, you’ll notice that the application fetched the https://jsonplaceholder.typicode.com/users URL, then used the results to build the Datagrid. That’s basically how react-admin works.

The list is already functional: you can reorder it by clicking on column headers, or change pages by using the bottom pagination controls. The ra-data-json-server data provider translates these actions to a query string that JSONPlaceholder understands.